### PR TITLE
Correctly encode ]]> sequences encountered in CDATA sources

### DIFF
--- a/lib/xml.js
+++ b/lib/xml.js
@@ -153,7 +153,9 @@ function resolve(data, indent, indent_count) {
             }
 
             if (values._cdata) {
-                content.push('<![CDATA[' + values._cdata + ']]>');
+                content.push(
+                    ('<![CDATA[' + values._cdata).replace(/\]\]>/g, ']]]]><![CDATA[>') + ']]>'
+                );
             }
 
             if (values.forEach) {

--- a/test/test.js
+++ b/test/test.js
@@ -57,6 +57,7 @@ module.exports = {
     cdata: function(test) {
         test.equal(XML([ { a: { _cdata: 'This is some <strong>CDATA</strong>' } } ]), '<a><![CDATA[This is some <strong>CDATA</strong>]]></a>');
         test.equal(XML([ { a: { _attr: { attribute1: 'some value', attribute2: 12345 },  _cdata: 'This is some <strong>CDATA</strong>' } } ]), '<a attribute1="some value" attribute2="12345"><![CDATA[This is some <strong>CDATA</strong>]]></a>');
+        test.equal(XML([ { a: { _cdata: 'This is some <strong>CDATA</strong> with ]]> and then again ]]>' } } ]), '<a><![CDATA[This is some <strong>CDATA</strong> with ]]]]><![CDATA[> and then again ]]]]><![CDATA[>]]></a>');
         test.done();
     },
 


### PR DESCRIPTION
This change applies http://en.wikipedia.org/wiki/CDATA#Nesting to CDATA sections.

Fixes dylang/node-rss#11.
