### PR TITLE
Handle null property values

### DIFF
--- a/lib/xml.js
+++ b/lib/xml.js
@@ -140,7 +140,7 @@ function resolve(data, indent, indent_count) {
         name = keys[0];
         values = data[name];
 
-        if (values._elem) {
+        if (values && values._elem) {
             values._elem.name = name;
             values._elem.icount = indent_count;
             values._elem.indent = indent;

--- a/test/xml.test.js
+++ b/test/xml.test.js
@@ -19,11 +19,13 @@ describe('xml module', function(done) {
 
     it('works with simple options', function(done) {
         expect(xml([ { a: {} }])).to.equal('<a/>');
+        expect(xml([ { a: null }])).to.equal('<a/>');
         expect(xml([ { a: [] }])).to.equal('<a></a>');
         expect(xml([ { a: -1 }])).to.equal('<a>-1</a>');
         expect(xml([ { a: false }])).to.equal('<a>false</a>');
         expect(xml([ { a: 'test' }])).to.equal('<a>test</a>');
         expect(xml( { a: {} })).to.equal('<a/>');
+        expect(xml( { a: null })).to.equal('<a/>');
         expect(xml( { a: [] })).to.equal('<a></a>');
         expect(xml( { a: -1 })).to.equal('<a>-1</a>');
         expect(xml( { a: false })).to.equal('<a>false</a>');


### PR DESCRIPTION
Fixes the error `TypeError: Cannot read property '_elem' of null` when a property has a value of `null`. Added assertion to test this case.
