### PR TITLE
Implements an option to prevent the automatic encoding

### DIFF
--- a/lib/xml.js
+++ b/lib/xml.js
@@ -2,6 +2,7 @@ var escapeForXML = require('./escapeForXML');
 var Stream = require('stream').Stream;
 
 var DEFAULT_INDENT = '    ';
+var SHOULD_ESCAPE = true
 
 function xml(input, options) {
 
@@ -19,6 +20,7 @@ function xml(input, options) {
                             : options.indent,
         instant     = true;
 
+    SHOULD_ESCAPE = options.escape === undefined ? SHOULD_ESCAPE : options.escape;
 
     function delay (func) {
         if (!instant) {
@@ -194,7 +196,7 @@ function resolve(data, indent, indent_count) {
                         //string
                         content.pop();
                         isStringContent=true;
-                        content.push(escapeForXML(value));
+                        content.push(SHOULD_ESCAPE ? escapeForXML(value) : value);
                     }
 
                 });
@@ -206,7 +208,7 @@ function resolve(data, indent, indent_count) {
 
         default:
             //string
-            content.push(escapeForXML(values));
+            content.push(SHOULD_ESCAPE ? escapeForXML(values) : values);
 
     }
 

--- a/test/xml.test.js
+++ b/test/xml.test.js
@@ -148,3 +148,8 @@ test('xml declaration options', t => {
     t.is(xml([{a: 'test'}], {declaration: true, indent: '\n'}), '<?xml version="1.0" encoding="UTF-8"?>\n<a>test</a>');
     t.is(xml([{a: 'test'}], {}), '<a>test</a>');
 });
+
+test('escape option', t => {
+    t.is(xml([ { x: '<a>test</a>' } ], { escape: false }), '<x><a>test</a></x>');
+    t.is(xml([ { x: [ { _attr: { a: 'x' } }, '<a>test</a>' ] } ], { escape: false }), '<x a="x"><a>test</a></x>');
+});


### PR DESCRIPTION
I'm implementing an Atom feed generator and I'd like to be able to disable the automatic string encoding.
