### PR TITLE
Fix for xml processing instructions

### DIFF
--- a/lib/xml.js
+++ b/lib/xml.js
@@ -66,9 +66,8 @@ function xml(input, options) {
         if (declaration.standalone) {
             attr.standalone = declaration.standalone
         }
-
+ 
         add({'?xml': { _attr: attr } });
-        output = output.replace('/>', '?>');
     }
 
     // disable delay delayed
@@ -240,7 +239,7 @@ function format(append, elem, end) {
         }
 
         append(false, (len > 1 ? elem.indents : '')
-            + (elem.name ? '</' + elem.name + '>' : '')
+            + (elem.name ? '<' + (/^\?/.test(elem.name)? '?' : '/') + elem.name + '>' : '')
             + (elem.indent && !end ? '\n' : ''));
 
         if (end) {
@@ -262,7 +261,7 @@ function format(append, elem, end) {
     append(false, elem.indents
         + (elem.name ? '<' + elem.name : '')
         + (elem.attributes.length ? ' ' + elem.attributes.join(' ') : '')
-        + (len ? (elem.name ? '>' : '') : (elem.name ? '/>' : ''))
+        + (len ? (elem.name ? '>' : '') : (elem.name ? (/^\?/.test(elem.name)? '?' : '/') + '>' : ''))
         + (elem.indent && len > 1 ? '\n' : ''));
 
     if (!len) {


### PR DESCRIPTION
As all XML processing instructions begin with a '?' in their name, I modified xml#format to use a '?' instead of a '/' when closing a tag.  This also means that xml#addXmlDeclaration no longer needs to manually replace the trailing '/' for the xml declaration.

https://www.w3.org/TR/xml11/#dt-pi