### PR TITLE
fix multiple input to xml() issue

### DIFF
--- a/lib/xml.js
+++ b/lib/xml.js
@@ -81,7 +81,7 @@ function xml(input, options) {
     if (input && input.forEach) {
         input.forEach(function (value, i) {
             var last;
-            if (i + 1 === input.length)
+            if (i == 0)
                 last = end;
             add(value, last);
         });

--- a/test/xml.test.js
+++ b/test/xml.test.js
@@ -148,3 +148,22 @@ test('xml declaration options', t => {
     t.is(xml([{a: 'test'}], {declaration: true, indent: '\n'}), '<?xml version="1.0" encoding="UTF-8"?>\n<a>test</a>');
     t.is(xml([{a: 'test'}], {}), '<a>test</a>');
 });
+
+test('multiple elements for xml', t=> {
+    var elem = xml.element({ _attr: { xmlns: 'http://www.opengis.net/kml/2.2'} });
+    var doc = xml.element({});
+
+    let output = "";
+
+    var stream = xml([{kml: elem}, {Document: doc}])
+    stream.on('data',  data => {
+        output += data;
+    });
+
+    stream.on('end',  () => {
+        t.is(output, '<kml xmlns="http://www.opengis.net/kml/2.2"><Document></Document></kml>');
+    });
+
+    doc.close();
+    elem.close();
+});


### PR DESCRIPTION
When multiple elements are passed into `xml()`, closing the first element should actually close the stream. The elements added to `xml()` should be closed in reverse order.
Please check #30 for details