### PR TITLE
Fix error when an empty array is used content

### DIFF
--- a/lib/xml.js
+++ b/lib/xml.js
@@ -178,6 +178,7 @@ function resolve(data, indent, indent_count) {
             }
 
             if (values.forEach) {
+                if (values.length === 0) break;
                 isStringContent = false;
                 content.push('');
                 values.forEach(function(value) {


### PR DESCRIPTION
When an empty array is used for content, there are no children. Currently it creates 2 empty strings as the children of the element, which then prevents `/>` from being used.